### PR TITLE
Spotfixes: Increase PHP Minimum, Remove Unique Key in SQL

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -14,7 +14,7 @@
  * Author: Constant Contact
  * Author URI: https://www.constantcontact.com/
  * Text Domain: cc-woo
- * Requires PHP: 7.0
+ * Requires PHP: 7.2
  * License: GPL-3.0+
  * License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
  */

--- a/src/AbandonedCarts/CartsTable.php
+++ b/src/AbandonedCarts/CartsTable.php
@@ -72,8 +72,7 @@ class CartsTable extends Service {
 			cart_created datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 			cart_created_ts int(11) unsigned NOT NULL DEFAULT 0,
 			cart_hash binary(16) NOT NULL DEFAULT 0,
-			PRIMARY KEY (cart_id),
-			UNIQUE KEY user (user_id, user_email)
+			PRIMARY KEY (cart_id)
 		) {$wpdb->get_charset_collate()}";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';


### PR DESCRIPTION
This solves for two issues.

---

### Issue One

First, the publicly-available version of 1.1.0 already declares a higher minimum PHP version than this feature branch's `7.0` — it requires `7.2`! I was surprised by this, but it's true.

### Fix
✔ Increase minimum required PHP version

---

### Issue Two

Next, the `UNIQUE KEY` statement in the `create_table` SQL was causing the following error on plugin activation:

```
[29-Oct-2019 11:38:03 UTC] WordPress database error Specified key was too long; max key length is 767 bytes for query CREATE TABLE wp_cc_abandoned_carts (
			cart_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
			user_id bigint(20) unsigned NOT NULL DEFAULT 0,
			user_email varchar(200) NOT NULL DEFAULT '',
			cart_contents longtext NOT NULL,
			cart_updated datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
			cart_updated_ts int(11) unsigned NOT NULL DEFAULT 0,
			cart_created datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
			cart_created_ts int(11) unsigned NOT NULL DEFAULT 0,
			cart_hash binary(16) NOT NULL DEFAULT 0,
			PRIMARY KEY (cart_id),
			UNIQUE KEY user (user_id, user_email)
		) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci made by activate_plugin, do_action('activate_constant-contact-woocommerce/plugin.php'), WP_Hook->do_action, WP_Hook->apply_filters, WebDevStudios\CCForWoo\Plugin->do_activation_process, WebDevStudios\CCForWoo\Plugin->create_abandoned_carts_table, WebDevStudios\CCForWoo\AbandonedCarts\CartsTable->create_table, dbDelta
```

This is because of the `UNIQUE KEY` statement. I started tinkering with how to fix it by keeping it—I figured maybe just specifying a max byte size for the key itself if possible would help? But upon quick researching I found that the Unique Key wasn't really necessary here in my opinion. Check out this resource for example → https://stackoverflow.com/a/13349176/815708

So I just removed the Unique Key declaration and tested a bit, and the everything worked well, including table creation on plugin activation.

### Fix
✔ Remove unique key declaration