### PR TITLE
CC-121: Abandoned Checkouts are not preserving the email address when returning to Cart

### DIFF
--- a/src/AbandonedCheckouts/CheckoutRecovery.php
+++ b/src/AbandonedCheckouts/CheckoutRecovery.php
@@ -76,12 +76,36 @@ class CheckoutRecovery extends Service {
 			WC()->cart->apply_coupon( $coupon );
 		}
 
+		// Maybe recover checkout email.
+		$this->maybe_recover_checkout_email();
+
 		// Update totals.
 		WC()->cart->calculate_totals();
 
 		// Redirect to checkout page.
 		wp_safe_redirect( wc_get_page_permalink( 'cart' ) );
 		exit();
+	}
+
+
+	/**
+	 * Recover checkout email address if guest user and no email is set.
+	 *
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT
+	 *
+	 * @return void
+	 */
+	protected function maybe_recover_checkout_email() : void {
+		$checkout_email = CheckoutHandler::get_checkout_data( 'user_email', 'checkout_uuid = %s', [ $this->checkout_uuid ] );
+		$checkout_email = empty( $checkout_email ) ? '' : array_shift( $checkout_email )->user_email;
+
+		if ( is_user_logged_in() || ! empty( WC()->session->get( 'billing_email' ) ) || empty( $checkout_email ) ) {
+			return;
+		}
+
+		WC()->session->set( 'billing_email', $checkout_email );
+		WC()->customer->set_billing_email( $checkout_email );
 	}
 
 	/**

--- a/src/AbandonedCheckouts/CheckoutRecovery.php
+++ b/src/AbandonedCheckouts/CheckoutRecovery.php
@@ -126,21 +126,4 @@ class CheckoutRecovery extends Service {
 			);
 		}
 	}
-
-	/**
-	 * Recover and apply customer billing and shipping info from saved checkout data.
-	 *
-	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  1.2.0
-	 * @param  array  $customer_info Array of customer billing and shipping info.
-	 * @param  string $type          Type of customer info to recover (billing or shipping).
-	 */
-	protected function recover_customer_info( $customer_info, string $type ) {
-		foreach ( $customer_info[ $type ] as $key => $value ) {
-			call_user_func(
-				[ WC()->customer, "set_{$type}_{$key}" ],
-				$value
-			);
-		}
-	}
 }


### PR DESCRIPTION
Ticket: [CC-121](https://webdevstudios.atlassian.net/browse/CC-121)

## Description ##

- Removes old unused `recover_customer_info` method from `CheckoutRecovery`.
- Adds functionality (and new method `maybe_recover_checkout_email`) to recover saved checkout user email IF the current site user is a guest (not logged in) AND they have not set an email in the current session.

## Testing ##

1. Create abandoned checkout (add items and at least enter an email address at checkout).
2. Either clear browser cache/session or open incognito browser.
3. Recover checkout: `<local_domain>/?recover-checkout=<checkout_uuid>` - `<checkout_uuid>` can be obtained from the db.
4. Go to checkout page and confirm email from original checkout is preserved.
5. Repeat steps 1, 3, 4 from another window that already has a checkout created (i.e., in incognito, create cart and enter a _different_ email address, then recover a different cart)
6. Go to checkout page and confirm email from the recovered cart does _not_ override the email that entered for this session.