### PR TITLE
Merge CC-110 work into sprint 20.02 so it doesn't get lost

### DIFF
--- a/src/View/Admin/WooTab.php
+++ b/src/View/Admin/WooTab.php
@@ -147,7 +147,6 @@ class WooTab extends WC_Settings_Page implements Hookable {
 	public function register_hooks() {
 		add_filter( 'woocommerce_settings_tabs_array', [ $this, 'add_settings_page' ], 99 );
 		add_action( "woocommerce_settings_{$this->id}", [ $this, 'output' ] );
-		add_action( "woocommerce_settings_{$this->id}", [ $this, 'enqueue_scripts' ] );
 
 		// Output settings sections.
 		add_action( "woocommerce_sections_{$this->id}", [ $this, 'output_sections' ] );


### PR DESCRIPTION
[CC-110](https://webdevstudios.atlassian.net/browse/CC-110) work was done during the 20.01 sprint, and PR'ed against the [sprint/20.01](https://github.com/WebDevStudios/constant-contact-woocommerce/commits/sprint/20.01) branch in #86.

However, the [sprint/20.01](https://github.com/WebDevStudios/constant-contact-woocommerce/commits/sprint/20.01) branch was never merged to master, as we did not do a release in January, and we are now in 20.03 sprint (but still using 20.02 branch).

[sprint/20.02](https://github.com/WebDevStudios/constant-contact-woocommerce/commits/sprint/20.02) branched off of master, without this work, leaving this orphaned on [sprint/20.01](https://github.com/WebDevStudios/constant-contact-woocommerce/commits/sprint/20.01).

We could merge [sprint/20.01](https://github.com/WebDevStudios/constant-contact-woocommerce/commits/sprint/20.01) branch into [sprint/20.02](https://github.com/WebDevStudios/constant-contact-woocommerce/commits/sprint/20.02), or just merge this issue branch [issue/CC-110-fix-php-warning-on-wootab-class](https://github.com/WebDevStudios/constant-contact-woocommerce/tree/issue/CC-110-fix-php-warning-on-wootab-class) into [sprint/20.02](https://github.com/WebDevStudios/constant-contact-woocommerce/commits/sprint/20.02) and close the [sprint/20.01](https://github.com/WebDevStudios/constant-contact-woocommerce/commits/sprint/20.01) branch.

![Screen Shot 2020-03-17 at 5 26 04 PM](https://user-images.githubusercontent.com/5407441/76912764-07422000-6883-11ea-8819-e36b9078ef05.png)
