### PR TITLE
Chore/increment version to 1.3.0-1

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: constantcontact, webdevstudios, znowebdev, jmichaelward, ggwicz, r
 Tags: capture, contacts, constant contact, constant contact form, constant contact newsletter, constant contact official, contact forms, email, form, forms, marketing, mobile, newsletter, opt-in, plugin, signup, subscribe, subscription, widget
 Requires at least: 5.2.2
 Tested up to: 5.3.0
-Stable tag: 1.2.0
+Stable tag: 1.3.0-1
 Requires PHP: 7.2
 WC tested up to: 3.8.1
 License: GPLv3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constant-contact-woocommerce",
-  "version": "1.2.0",
+  "version": "1.3.0-1",
   "description": "",
   "main": "index.js",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -10,7 +10,7 @@
  * Plugin Name: Constant Contact + WooCommerce
  * Description: Add products to your emails and sync your contacts.
  * Plugin URI: https://github.com/WebDevStudios/constant-contact-woocommerce
- * Version: 1.2.0
+ * Version: 1.3.0-1
  * Author: Constant Contact
  * Author URI: https://www.constantcontact.com/
  * Text Domain: cc-woo

--- a/src/AbandonedCheckouts/CheckoutHandler.php
+++ b/src/AbandonedCheckouts/CheckoutHandler.php
@@ -183,7 +183,7 @@ class CheckoutHandler extends Service {
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
 	 *
-	 * @since  NEXT
+	 * @since  1.3.0
 	 * @return string Checkout UUID if exists, else empty string.
 	 */
 	public static function get_checkout_uuid_by_user() {

--- a/src/AbandonedCheckouts/CheckoutRecovery.php
+++ b/src/AbandonedCheckouts/CheckoutRecovery.php
@@ -92,7 +92,7 @@ class CheckoutRecovery extends Service {
 	 * Recover checkout email address if guest user and no email is set.
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  1.3.0
 	 *
 	 * @return void
 	 */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -46,7 +46,7 @@ final class Plugin extends ServiceRegistrar {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const PLUGIN_VERSION = '1.2.0';
+	const PLUGIN_VERSION = '1.3.0-1';
 
 	/**
 	 * Whether the plugin is currently active.

--- a/src/Rest/AbandonedCheckouts/Controller.php
+++ b/src/Rest/AbandonedCheckouts/Controller.php
@@ -178,7 +178,7 @@ class Controller extends WP_REST_Controller {
 	 * @since 2019-10-28
 	 *
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since NEXT - Updated to fit CheckoutHandler::get_checkout_data setup for WHERE clause.
+	 * @since 1.3.0 - Updated to fit CheckoutHandler::get_checkout_data setup for WHERE clause.
 	 *
 	 * @param string $date_min The oldest created_at date to get results from.
 	 * @param string $date_max The most recent created_at date to get results from.


### PR DESCRIPTION
Per the email we received today, going with targeted release version of `1.3.0`.

Checkout method's `@since` tags will use `1.3.0` since that's the target release number.

Everything else updated to version-build `1.3.0-1` for the QA team's parser.