### PR TITLE
CC-125 Move the 'WC tested up to' tag from README.txt to plugin.php

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,6 @@ Requires at least: 5.2.2
 Tested up to: 5.3.0
 Stable tag: 1.3.0-1
 Requires PHP: 7.2
-WC tested up to: 3.8.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/plugin.php
+++ b/plugin.php
@@ -14,6 +14,7 @@
  * Author: Constant Contact
  * Author URI: https://www.constantcontact.com/
  * Text Domain: cc-woo
+ * WC tested up to: 3.8.1
  * Requires PHP: 7.2
  * License: GPL-3.0+
  * License URI: https://www.gnu.org/licenses/gpl-3.0.en.html


### PR DESCRIPTION
As noted in [CC-125](https://webdevstudios.atlassian.net/browse/CC-125), WooCommerce was unable to determine what version of Woo we declare support for, as the "WC tested up to" tag was in the wrong place, it does not belong in the README.txt, but in the plugin header.

Before:
![Screen Shot 2020-03-18 at 3 31 28 PM](https://user-images.githubusercontent.com/5407441/77097302-93b52580-69de-11ea-9583-958201d6459d.png)

After:
![Screen Shot 2020-03-19 at 12 34 41 PM](https://user-images.githubusercontent.com/5407441/77097319-9b74ca00-69de-11ea-82a8-4c58df6a6e6c.png)

