### PR TITLE
CC-126: Test CC-Woo against latest WordPress and WooCommerce versions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: constantcontact, webdevstudios, znowebdev, jmichaelward, ggwicz, ravedev
 Tags: capture, contacts, constant contact, constant contact form, constant contact newsletter, constant contact official, contact forms, email, form, forms, marketing, mobile, newsletter, opt-in, plugin, signup, subscribe, subscription, widget
 Requires at least: 5.2.2
-Tested up to: 5.3.0
+Tested up to: 5.4.0
 Stable tag: 1.3.0-1
 Requires PHP: 7.2
 License: GPLv3

--- a/plugin.php
+++ b/plugin.php
@@ -14,7 +14,7 @@
  * Author: Constant Contact
  * Author URI: https://www.constantcontact.com/
  * Text Domain: cc-woo
- * WC tested up to: 3.8.1
+ * WC tested up to: 4.0.1
  * Requires PHP: 7.2
  * License: GPL-3.0+
  * License URI: https://www.gnu.org/licenses/gpl-3.0.en.html


### PR DESCRIPTION
Bump `WC tested up to` to `4.0.1`
Bump `WP Tested up to` to `5.4.0` (Tested with RC3 on Lab)