### PR TITLE
CC-64: Update instances of `add_post_meta`

### DIFF
--- a/src/View/Checkout/CampaignId.php
+++ b/src/View/Checkout/CampaignId.php
@@ -10,6 +10,7 @@
 
 namespace WebDevStudios\CCForWoo\View\Checkout;
 
+use \WC_Order;
 use WebDevStudios\OopsWP\Utility\Hookable;
 
 /**
@@ -37,7 +38,7 @@ class CampaignId implements Hookable {
 	 */
 	public function register_hooks() {
 		add_action( 'init', [ $this, 'save_campaign_id' ], 11 );
-		add_action( 'woocommerce_checkout_update_order_meta', [ $this, 'save_user_campaign_id_to_order' ] );
+		add_action( 'woocommerce_checkout_create_order', [ $this, 'save_user_campaign_id_to_order' ] );
 	}
 
 	/**
@@ -47,16 +48,20 @@ class CampaignId implements Hookable {
 	 *
 	 * @author Michael Beckwith <michael@webdevstudios.com>
 	 * @since  2019-08-22
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT Changed hook to `woocommerce_checkout_create_order` and changed "save order meta" function.
+	 * 
+	 * @param  WC_Order $order WC Order instance.
 	 * @return void
 	 */
-	public function save_user_campaign_id_to_order( $order_id ) {
+	public function save_user_campaign_id_to_order( WC_Order $order ) {
 		$preference = $this->get_stored_campaign_id();
 
 		if ( empty( $preference ) ) {
 			return;
 		}
 
-		add_post_meta( $order_id, self::CUSTOMER_CAMPAIGN_ID_KEY, $preference, true );
+		$order->update_meta_data( self::CUSTOMER_CAMPAIGN_ID_KEY, $preference );
 	}
 
 	/**

--- a/src/View/Checkout/NewsletterPreferenceCheckbox.php
+++ b/src/View/Checkout/NewsletterPreferenceCheckbox.php
@@ -11,6 +11,7 @@
 
 namespace WebDevStudios\CCForWoo\View\Checkout;
 
+use \WC_Order;
 use WebDevStudios\CCForWoo\Utility\NonceVerification;
 use WebDevStudios\OopsWP\Utility\Hookable;
 
@@ -63,7 +64,7 @@ class NewsletterPreferenceCheckbox implements Hookable {
 		add_action( 'woocommerce_after_checkout_billing_form', [ $this, 'add_field_to_billing_form' ] );
 		add_action( 'woocommerce_checkout_update_user_meta', [ $this, 'save_user_preference' ] );
 		add_action( 'woocommerce_created_customer', [ $this, 'save_user_preference' ] );
-		add_action( 'woocommerce_checkout_update_order_meta', [ $this, 'save_user_preference_to_order' ] );
+		add_action( 'woocommerce_checkout_create_order', [ $this, 'save_user_preference_to_order' ] );
 	}
 
 	/**
@@ -150,16 +151,20 @@ class NewsletterPreferenceCheckbox implements Hookable {
 	 *
 	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
 	 * @since  2019-03-18
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  NEXT Changed hook to `woocommerce_checkout_create_order` and changed "save order meta" function.
+	 *
+	 * @param  WC_Order $order WC Order instance.
 	 * @return void
 	 */
-	public function save_user_preference_to_order( $order_id ) {
+	public function save_user_preference_to_order( WC_Order $order ) {
 		$preference = $this->get_submitted_customer_preference();
 
 		if ( empty( $preference ) ) {
 			return;
 		}
 
-		add_post_meta( $order_id, self::CUSTOMER_PREFERENCE_META_FIELD, $preference, true );
+		$order->update_meta_data( self::CUSTOMER_PREFERENCE_META_FIELD, $preference );
 	}
 
 	/**


### PR DESCRIPTION
Ticket: [CC-64](https://webdevstudios.atlassian.net/browse/CC-64)

## Description ##

Updates instances of `add_post_meta()` to `$order->update_meta_data` and changes corresponding hooks to `woocommerce_checkout_create_order` (as that hook passes the full `WC_Order` object instead of just `$order_id`).

## Testing ##

Place and order and confirm `cc_woo_customer_agrees_to_marketing` is added to the order metadata if "Sign me up to receive marketing emails (optional)" is selected at checkout.