### PR TITLE
Chore/prep release 1.3.1

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: constantcontact, webdevstudios, znowebdev, jmichaelward, ggwicz, r
 Tags: capture, contacts, constant contact, constant contact form, constant contact newsletter, constant contact official, contact forms, email, form, forms, marketing, mobile, newsletter, opt-in, plugin, signup, subscribe, subscription, widget
 Requires at least: 5.2.2
 Tested up to: 5.4.0
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 Requires PHP: 7.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/README.txt
+++ b/README.txt
@@ -43,6 +43,11 @@ With Constant Contact you can:
 
 == Changelog ==
 
+= 1.3.1 =
+
+* Tweak - Change `CampaignId::save_user_campaign_id_to_order` and `NewsletterPreferenceCheckbox::save_user_preference_to_order` methods to fire on `woocommerce_checkout_create_order` hook.
+* Tweak - Replace `add_post_meta` usage with `$order->update_meta_data` in `CampaignId::save_user_campaign_id_to_order` and `NewsletterPreferenceCheckbox::save_user_preference_to_order` methods.
+
 = 1.3.0 =
 
 * Updated - Revised abandoned cart functionality to instead be abandoned checkouts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constant-contact-woocommerce",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "index.js",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -10,7 +10,7 @@
  * Plugin Name: Constant Contact + WooCommerce
  * Description: Add products to your emails and sync your contacts.
  * Plugin URI: https://github.com/WebDevStudios/constant-contact-woocommerce
- * Version: 1.3.0
+ * Version: 1.3.1
  * Author: Constant Contact
  * Author URI: https://www.constantcontact.com/
  * Text Domain: cc-woo

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -46,7 +46,7 @@ final class Plugin extends ServiceRegistrar {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const PLUGIN_VERSION = '1.3.0';
+	const PLUGIN_VERSION = '1.3.1';
 
 	/**
 	 * Whether the plugin is currently active.

--- a/src/View/Checkout/CampaignId.php
+++ b/src/View/Checkout/CampaignId.php
@@ -49,7 +49,7 @@ class CampaignId implements Hookable {
 	 * @author Michael Beckwith <michael@webdevstudios.com>
 	 * @since  2019-08-22
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT Changed hook to `woocommerce_checkout_create_order` and changed "save order meta" function.
+	 * @since  1.3.1 Changed hook to `woocommerce_checkout_create_order` and changed "save order meta" function.
 	 * 
 	 * @param  WC_Order $order WC Order instance.
 	 * @return void

--- a/src/View/Checkout/NewsletterPreferenceCheckbox.php
+++ b/src/View/Checkout/NewsletterPreferenceCheckbox.php
@@ -152,7 +152,7 @@ class NewsletterPreferenceCheckbox implements Hookable {
 	 * @author Jeremy Ward <jeremy.ward@webdevstudios.com>
 	 * @since  2019-03-18
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
-	 * @since  NEXT Changed hook to `woocommerce_checkout_create_order` and changed "save order meta" function.
+	 * @since  1.3.1 Changed hook to `woocommerce_checkout_create_order` and changed "save order meta" function.
 	 *
 	 * @param  WC_Order $order WC Order instance.
 	 * @return void


### PR DESCRIPTION
Replace `@since NEXT` with `@since 1.3.1`
Increment PLUGIN_VERSION constant to 1.3.1
Increment Version in plugin header to 1.3.1
Increment Stable tag in README.txt to 1.3.1
Increment version in package.json to 1.3.1
Add 1.3.1 to Changelog in README.txt