### PR TITLE
CC-145 Use WC_Validation::is_phone() rather than homespun regex

### DIFF
--- a/src/Settings/SettingsValidator.php
+++ b/src/Settings/SettingsValidator.php
@@ -103,7 +103,9 @@ class SettingsValidator implements Validatable {
 	 * @return bool
 	 */
 	private function has_valid_phone(): bool {
-		return WC_Validation::is_phone( $this->settings->get_phone_number() );
+		return ! empty( $this->settings->get_phone_number() )
+			? WC_Validation::is_phone( $this->settings->get_phone_number() )
+			: false;
 	}
 
 	/**

--- a/src/Settings/SettingsValidator.php
+++ b/src/Settings/SettingsValidator.php
@@ -12,6 +12,7 @@
 namespace WebDevStudios\CCForWoo\Settings;
 
 use WebDevStudios\CCForWoo\Utility\Validatable;
+use WC_Validation;
 
 /**
  * Class SettingsValidator
@@ -94,21 +95,15 @@ class SettingsValidator implements Validatable {
 	/**
 	 * Verify that the phone number is valid.
 	 *
-	 * @since 2019-03-08
+	 * @since  2019-03-08
 	 * @author Zach Owen <zach@webdevstudios>
+	 *
+	 * @uses   WC_Validation::is_phone()
+	 *
 	 * @return bool
 	 */
-	private function has_valid_phone() {
-		$phone_number = $this->settings->get_phone_number();
-
-		if ( '+' === substr( $phone_number, 0, 1 ) ) {
-			$phone_number = substr( $phone_number, 1 );
-		}
-
-		preg_match( '/^[\d\-()]/', $phone_number, $matches );
-		preg_match( '/[^\d\-()]/', $phone_number, $invalid_matches );
-
-		return ! empty( $matches[0] ) && empty( $invalid_matches );
+	private function has_valid_phone(): bool {
+		return WC_Validation::is_phone( $this->settings->get_phone_number() );
 	}
 
 	/**

--- a/src/View/Admin/WooTab.php
+++ b/src/View/Admin/WooTab.php
@@ -711,7 +711,7 @@ class WooTab extends WC_Settings_Page implements Hookable {
 	}
 
 	/**
-	 * Sanitize the phone number to only include digits, -, and (, )
+	 * Sanitize incoming phone number.
 	 *
 	 * @since  2019-03-08
 	 * @author Zach Owen <zach@webdevstudios>
@@ -721,7 +721,7 @@ class WooTab extends WC_Settings_Page implements Hookable {
 	 * @return string
 	 */
 	public function sanitize_phone_number( $value ) {
-		return is_scalar( $value ) ? preg_replace( '/[^\d\-()+]+/', '', $value ) : '';
+		return wc_sanitize_phone_number( $value );
 	}
 
 	/**

--- a/src/View/Admin/WooTab.php
+++ b/src/View/Admin/WooTab.php
@@ -836,6 +836,11 @@ class WooTab extends WC_Settings_Page implements Hookable {
 	public function save() {
 		parent::save();
 
+		// Prevent redirect to customer_data_import screen if we don't meet connection requirements.
+		if ( ! $this->meets_connect_requirements() ) {
+			return;
+		}
+
 		if ( $this->connection->is_connected() || $this->has_active_settings_section() ) {
 			return;
 		}


### PR DESCRIPTION
More details added to ticket [CC-145](https://webdevstudios.atlassian.net/browse/CC-145).

Updated PR...
Use WooCommerce WC_Validation::is_phone() rather than homespun regex
has_valid_phone should return false if phone number is empty
Use WooCommerce wc_sanitize_phone_number() rather than homespun regex
Do not redirect to customer_data_import screen if we don't meet requirements
