### PR TITLE
CC-145 Provide fallback if wc_sanitize_phone_number isn't available

### DIFF
--- a/src/View/Admin/WooTab.php
+++ b/src/View/Admin/WooTab.php
@@ -721,7 +721,11 @@ class WooTab extends WC_Settings_Page implements Hookable {
 	 * @return string
 	 */
 	public function sanitize_phone_number( $value ) {
-		return wc_sanitize_phone_number( $value );
+		if ( function_exists( 'wc_sanitize_phone_number' ) ) {
+			return wc_sanitize_phone_number( $value );
+		}
+
+		return preg_replace( '/[^\d+]/', '', $value );
 	}
 
 	/**


### PR DESCRIPTION
The wc_sanitize_phone_number function has only been available since WC 3.6.0.
Saw at least one support forum user running WC 3.4.2.