### PR TITLE
CC-161: Add WC min version to plugin header

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -14,6 +14,7 @@
  * Author: Constant Contact
  * Author URI: https://www.constantcontact.com/
  * Text Domain: cc-woo
+ * WC requires at least: 3.6.0
  * WC tested up to: 4.0.1
  * Requires PHP: 7.2
  * License: GPL-3.0+


### PR DESCRIPTION
[CC-161](https://webdevstudios.atlassian.net/browse/CC-161)

Adds `WC requires at least: 3.6.0` to plugin header.