### PR TITLE
Added support to change opt-in location.

### DIFF
--- a/src/View/Admin/WooTab.php
+++ b/src/View/Admin/WooTab.php
@@ -488,8 +488,8 @@ class WooTab extends WC_Settings_Page implements Hookable {
 				'id'      => self::CHECKBOX_LOCATION,
 				'default' => 'false',
 				'options' => [
-					'woocommerce_after_checkout_billing_form' => esc_html__( 'woocommerce_after_checkout_billing_form', 'cc-woo' ),
-					'woocommerce_review_order_before_submit'  => esc_html__( 'woocommerce_review_order_before_submit', 'cc-woo' ),
+					'woocommerce_after_checkout_billing_form' => esc_html__( 'After Checkout Billing Form', 'cc-woo' ),
+					'woocommerce_review_order_before_submit'  => esc_html__( 'Before order submit button', 'cc-woo' ),
 				],
 			],
 			[
@@ -662,7 +662,7 @@ class WooTab extends WC_Settings_Page implements Hookable {
 			get_option( self::CURRENCY_FIELD, '' ),
 			get_option( self::COUNTRY_CODE_FIELD ),
 			get_option( self::EMAIL_FIELD ),
-			get_option( self::CHECKBOX_LOCATION )
+			get_option( self::CHECKBOX_LOCATION, 'woocommerce_after_checkout_billing_form' )
 		);
 
 		$validator = new SettingsValidator( $model );

--- a/src/View/Admin/WooTab.php
+++ b/src/View/Admin/WooTab.php
@@ -507,7 +507,7 @@ class WooTab extends WC_Settings_Page implements Hookable {
 				'id'      => self::CHECKBOX_LOCATION,
 				'default' => 'false',
 				'options' => [
-					'woocommerce_after_checkout_billing_form' => esc_html__( 'After Checkout Billing Form', 'cc-woo' ),
+					'woocommerce_after_checkout_billing_form' => esc_html__( 'After checkout billing form', 'cc-woo' ),
 					'woocommerce_review_order_before_submit'  => esc_html__( 'Before order submit button', 'cc-woo' ),
 				],
 			],

--- a/src/View/Admin/WooTab.php
+++ b/src/View/Admin/WooTab.php
@@ -77,6 +77,13 @@ class WooTab extends WC_Settings_Page implements Hookable {
 	const EMAIL_FIELD = 'cc_woo_store_information_contact_email';
 
 	/**
+	 * Store checkbox location.
+	 *
+	 * @since 2021-07-26
+	 */
+	const CHECKBOX_LOCATION = 'cc_woo_store_information_checkbox_location';
+
+	/**
 	 * Settings section ID.
 	 *
 	 * @var string
@@ -475,6 +482,17 @@ class WooTab extends WC_Settings_Page implements Hookable {
 				],
 			],
 			[
+				'title'   => esc_html__( 'Checkbox Filter Location', 'cc-woo' ),
+				'desc'    => esc_html__( 'Change filter location where checkbox is rendered.', 'cc-woo' ),
+				'type'    => 'select',
+				'id'      => self::CHECKBOX_LOCATION,
+				'default' => 'false',
+				'options' => [
+					'woocommerce_after_checkout_billing_form' => esc_html__( 'woocommerce_after_checkout_billing_form', 'cc-woo' ),
+					'woocommerce_review_order_before_submit'  => esc_html__( 'woocommerce_review_order_before_submit', 'cc-woo' ),
+				],
+			],
+			[
 				'type' => 'sectionend',
 				'id'   => 'cc_woo_store_information_settings',
 			],
@@ -643,7 +661,8 @@ class WooTab extends WC_Settings_Page implements Hookable {
 			get_option( self::STORE_NAME_FIELD, '' ),
 			get_option( self::CURRENCY_FIELD, '' ),
 			get_option( self::COUNTRY_CODE_FIELD ),
-			get_option( self::EMAIL_FIELD )
+			get_option( self::EMAIL_FIELD ),
+			get_option( self::CHECKBOX_LOCATION )
 		);
 
 		$validator = new SettingsValidator( $model );

--- a/src/View/Checkout/NewsletterPreferenceCheckbox.php
+++ b/src/View/Checkout/NewsletterPreferenceCheckbox.php
@@ -61,7 +61,9 @@ class NewsletterPreferenceCheckbox implements Hookable {
 	 * @since 2019-03-13
 	 */
 	public function register_hooks() {
-		add_action( 'woocommerce_after_checkout_billing_form', [ $this, 'add_field_to_billing_form' ] );
+
+		$checkbox_location = get_option( 'cc_woo_store_information_checkbox_location', 'woocommerce_after_checkout_billing_form' );
+		add_action( $checkbox_location, [ $this, 'add_field_to_billing_form' ] );
 		add_action( 'woocommerce_checkout_update_user_meta', [ $this, 'save_user_preference' ] );
 		add_action( 'woocommerce_created_customer', [ $this, 'save_user_preference' ] );
 		add_action( 'woocommerce_checkout_create_order', [ $this, 'save_user_preference_to_order' ] );


### PR DESCRIPTION
Ticket: https://webdevstudios.atlassian.net/browse/CC-223

Description: Adds setting to change where opt-in location is displayed to now choose between the `woocommerce_after_checkout_billing_form` or `woocommerce_review_order_before_submit` hook.

![image](https://user-images.githubusercontent.com/17047900/127041593-22a9af1e-045c-40d9-a78f-38c91d7fb5e6.png)
