### PR TITLE
Feature/node14 npm7

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/fermium

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,10 @@
         "webpack": "^5.45.0",
         "webpack-cli": "^3.3.11",
         "y18n": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.3.3",
   "description": "",
   "main": "index.js",
+  "engines": {
+    "node": ">=14",
+    "npm": ">=7"
+  },
   "dependencies": {
     "filter-validate-email": "^1.0.4"
   },


### PR DESCRIPTION
To ensure we all stay on the same page regarding Node and NPM versions to use for frontend packages and build processes...
* Set engines to Node 14 and NPM 7
* Add .nvmrc file specifying lts/fermium (Node 14.x)
