### PR TITLE
Feature/cc 305 new tab for dashboard

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -64,6 +64,10 @@ Customers
 
 == Changelog ==
 
+= 1.4.1 =
+
+* Updated - Constant Contact Dashboard button now opens Dashboard in a new tab.
+
 = 1.4.0 =
 
 * New - Add Checkbox Filter Location setting

--- a/src/View/Admin/WooTab.php
+++ b/src/View/Admin/WooTab.php
@@ -376,6 +376,7 @@ class WooTab extends WC_Settings_Page implements Hookable {
 		?>
 		<a
 			class="button button-primary"
+			target="_blank"
 			href="<?php echo esc_url( $url ); ?>"
 		>
 			<?php esc_html_e( 'Constant Contact Dashboard', 'cc-woo' ); ?>


### PR DESCRIPTION
Once connected to Constant Contact, the "Constant Contact Dashboard" button (link) will now open the dashboard in a new tab.