### PR TITLE
Feature/cc 306 import contact field

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -64,6 +64,11 @@ Customers
 
 == Changelog ==
 
+= 1.4.1 =
+
+* Updated - Set default value for importing contacts to 'true'.
+* Fix - Fixed broken form field layout on 'Import your contacts' tab.
+
 = 1.4.0 =
 
 * New - Add Checkbox Filter Location setting

--- a/src/View/Admin/Field/ImportHistoricalData.php
+++ b/src/View/Admin/Field/ImportHistoricalData.php
@@ -40,7 +40,6 @@ class ImportHistoricalData {
 			'default'           => 'true',
 			'custom_attributes' => $this->get_custom_attributes(),
 			'options'           => [
-				''      => '----',
 				'false' => esc_html__( 'No', 'cc-woo' ),
 				'true'  => esc_html__( 'Yes', 'cc-woo' ),
 			],

--- a/src/View/Admin/Field/ImportHistoricalData.php
+++ b/src/View/Admin/Field/ImportHistoricalData.php
@@ -37,7 +37,7 @@ class ImportHistoricalData {
 			'desc'              => $this->get_description(),
 			'type'              => 'select',
 			'id'                => self::OPTION_FIELD_NAME,
-			'default'           => '',
+			'default'           => 'true',
 			'custom_attributes' => $this->get_custom_attributes(),
 			'options'           => [
 				''      => '----',

--- a/src/View/Admin/WooTab.php
+++ b/src/View/Admin/WooTab.php
@@ -178,9 +178,6 @@ class WooTab extends WC_Settings_Page implements Hookable {
 		add_filter( 'woocommerce_settings_start', [ $this, 'validate_option_values' ], 10, 3 );
 		add_action( "woocommerce_settings_save_{$this->id}", [ $this, 'save' ] );
 		add_action( "woocommerce_settings_save_{$this->id}", [ $this, 'update_setup_option' ] );
-
-		// Custom field for labels.
-		add_action( 'woocommerce_admin_field_cc_woo_anti_spam_notice', [ $this, 'display_anti_spam_notice' ] );
 	}
 
 	/**
@@ -507,37 +504,33 @@ class WooTab extends WC_Settings_Page implements Hookable {
 	 * @return array
 	 */
 	private function get_customer_data_settings() {
+
+		$historical_import_field = new \WebDevStudios\CCForWoo\View\Admin\Field\ImportHistoricalData();
+
 		$settings = [
 			[
 				'title' => esc_html__( 'Import your contacts', 'cc-woo' ),
 				'id'    => 'cc_woo_customer_data_settings',
 				'type'  => 'title',
+				'desc'  => wp_kses(
+					sprintf(
+						__( "Start marketing to your customers right away by importing all your contacts now.\n\nDo you want to import your current contacts? By selecting yes below, you agree you have permission to market to your current contacts. \n\nSee more on Constant Contact's <a href='%s' target='_blank'>anti-spam policy</a>.", 'cc-woo' ),
+						esc_url( 'https://www.constantcontact.com/legal/anti-spam' )
+					),
+					[
+						'a' => [
+							'href' => [],
+							'target' => [],
+						],
+					]
+				)
 			],
-			[
-				'title' => '',
-				'id'    => 'cc_woo_customer_data_message',
-				'type'  => 'title',
-				'desc'  => esc_html__( "Start marketing to your customers right away by importing all your contacts now.\n\nDo you want to import your current contacts? By selecting yes below, you agree you have permission to market to your current contacts.", 'cc-woo' ),
-			],
-		];
-
-		$historical_import_field = new \WebDevStudios\CCForWoo\View\Admin\Field\ImportHistoricalData();
-
-		$settings[] = array_merge(
-			$settings,
 			$historical_import_field->get_form_field(),
 			[
-				[
-					'title' => '',
-					'type'  => 'cc_woo_anti_spam_notice',
-					'id'    => 'anti-spam-notice',
-				],
-				[
-					'type' => 'sectionend',
-					'id'   => 'cc_woo_customer_data_settings',
-				],
-			]
-		);
+				'type' => 'sectionend',
+				'id'   => 'cc_woo_customer_data_settings',
+			],
+		];
 
 		return $settings;
 	}
@@ -829,28 +822,6 @@ class WooTab extends WC_Settings_Page implements Hookable {
 	 */
 	public function get_woo_country() : string {
 		return wc_get_base_location()['country'] ?? '';
-	}
-
-	/**
-	 * Display a link to the anti-spam policy.
-	 *
-	 * @since 2019-05-17
-	 * @author Zach Owen <zach@webdevstudios>
-	 */
-	public function display_anti_spam_notice() {
-?>
-<tr>
-	<td colspan="2">
-		<?php
-		echo sprintf(
-			// phpcs:ignore -- output is escaped properly with esc_url.
-			__( 'See more on Constant Contact\'s <a href="%s" target="_blank">anti-spam policy</a>.', 'cc-woo' ),
-			esc_url( 'https://www.constantcontact.com/legal/anti-spam' )
-		);
-		?>
-	</td>
-</tr>
-<?php
 	}
 
 	/**


### PR DESCRIPTION
Closes CC-306

- Fixes the layout of the fields on the _Import you contacts_  tab under the Constant Contact WooCommerce options. The layout issues caused the spam info link not to be displayed and caused the select field to be displayed above the Save Changes button.
- Updated the default option for the _Import your contacts_ select box to _Yes_ and removed the empty choice.

**Before:**

![image](https://user-images.githubusercontent.com/12645132/165586370-2a3e9895-386b-4d7a-8a5e-b8cd309d7122.png)

**After:**

![image](https://user-images.githubusercontent.com/12645132/165586350-12d68f5e-7af9-467f-9282-32df21f69aca.png)
