### PR TITLE
CC - 313 :: Notfiy about the SSL requirement 

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -106,7 +106,7 @@ final class Plugin extends ServiceRegistrar {
 		$connected = get_option( 'cc_woo_import_connection_established' );
 
 		if ( ! $connected && 'on' !== $_SERVER['HTTPS'] ) {
-			$message = __( 'Your site does not appear to be using a secure connection (SSL). You might face issues when connecting to your account. Please add HTTPS to your site to make sure you have no issues connecting.', 'sample-text-domain' );
+			$message = __( 'Your site does not appear to be using a secure connection (SSL). You might face issues when connecting to your account. Please add HTTPS to your site to make sure you have no issues connecting.', 'cc-woo' );
 			new Notice(
 				new NoticeMessage( $message, 'error', true )
 			);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -93,6 +93,25 @@ final class Plugin extends ServiceRegistrar {
 	 */
 	public function __construct( string $plugin_file ) {
 		$this->plugin_file = $plugin_file;
+		add_action( 'admin_notices', [ $this, 'add_ssl_notice' ] );
+	}
+
+	/**
+	 * Returns a notice if SSL is not active.
+	 *
+	 * @since ??
+	 * @author Biplav Subedi <biplav.subedi@webdevstudios.com>
+	 */
+	public function add_ssl_notice() {
+		$connected = get_option( 'cc_woo_import_connection_established' );
+
+		if ( ! $connected && 'on' !== $_SERVER['HTTPS'] ) {
+			$message = __( 'Your site does not appear to be using a secure connection (SSL). You might face issues when connecting to your account. Please add HTTPS to your site to make sure you have no issues connecting.', 'sample-text-domain' );
+			new Notice(
+				new NoticeMessage( $message, 'error', true )
+			);
+		}
+		
 	}
 
 	/**
@@ -159,6 +178,8 @@ final class Plugin extends ServiceRegistrar {
 		} catch ( Exception $e ) {
 			$this->deactivate( $e->getMessage() );
 		}
+
+
 	}
 
 	/**


### PR DESCRIPTION
Since there was no other way to use HTTP instead of HTTPS on sites that don't have SSL enabled, I've added a notice to make sure they enable SSL before they connect to CTCT WOO plugin. 
This happens due to wrong protocol return from the Authorization url or middleware which forces the use of SSL.

https://webdevstudios.atlassian.net/browse/CC-313?atlOrigin=eyJpIjoiY2I5ODdkYjgzNDRjNGYzMmE1Mzc2Y2ZhODIxNTU1MzgiLCJwIjoiaiJ9