### PR TITLE
FIX :: check if SSL is present on the server.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -107,13 +107,12 @@ final class Plugin extends ServiceRegistrar {
 	public function add_ssl_notice() {
 		$connected = get_option( 'cc_woo_import_connection_established' );
 
-		if ( ! $connected && 'on' !== $_SERVER['HTTPS'] ) {
+		if ( ! $connected && ( isset( $_SERVER['HTTPS'] ) && 'on' !== $_SERVER['HTTPS'] ) ) {
 			$message = __( 'Your site does not appear to be using a secure connection (SSL). You might face issues when connecting to your account. Please add HTTPS to your site to make sure you have no issues connecting.', 'cc-woo' );
 			new Notice(
 				new NoticeMessage( $message, 'error', true )
 			);
 		}
-		
 	}
 
 	/**


### PR DESCRIPTION
## Issue Description
We have a PHP warning from the plugin when SSL is not present on the site that came with a faulty check when notice was added for sites not having SSL.

<!-- Jira ticket -->
## Ticket
https://webdevstudios.atlassian.net/browse/CC-325


