### PR TITLE
fix::added phpcs xml file to exclude list on composer archive.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
 		"generate-fixtures": [ "@php ./tests/cypress/bin/generate-cypress-fixtures.php" ],
 		"dist": [
 			"rm -rf ./vendor",
-			"rm -rf ./phpcs.xml.dist",
 			"@composer install --no-dev -a",
 			"@composer archive --format=zip --file constant-contact-woocommerce",
 			"mv constant-contact-woocommerce.zip $HOME/Desktop"
@@ -55,6 +54,7 @@
 			"cypress.*",
 			"phpunit.xml",
 			"README.md",
+			"phpcs.xml.dist",
 			"tags"
 		]
 	}


### PR DESCRIPTION
## Issue Description
The plugin removes the PHPCS XML file when a zip file for release is created with composer for some reason. This PR removes that but also makes sure that the file is not present on the release zip. 

<!-- Jira ticket -->
## Ticket
https://webdevstudios.atlassian.net/browse/CC-327

