### PR TITLE
Fixed :: WebPack not building files correctly. 

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,12 @@
 const path = require('path');
 
 module.exports = {
-	entry: './app/index.js',
-	output: {
-		filename: 'bundle.js',
-		path: path.resolve(__dirname, 'app')
+	entry: {
+		'bundle': './app/index.js',
+		'admin-bundle': './app/admin.js',
 	},
-	entry: './app/admin.js',
 	output: {
-		filename: 'admin-bundle.js',
+		filename: '[name].js',
 		path: path.resolve(__dirname, 'app')
 	},
 	module: {


### PR DESCRIPTION
On 2.0.0 I added multiple entries for WebPack was was not building the old frontend js files. Fortunately no changes were made on those files so we have no issues on the current live version. 
This PR fixes the WebPack entries and builds into respective files. 

Creating this PR to Main instead of a release branch since we might need it for development for the next release. 