### PR TITLE
declare compatibility with HPOS

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -31,3 +31,13 @@ require_once $cc_woo_autoloader;
 
 $cc_woo_plugin = new \WebDevStudios\CCForWoo\Plugin( __FILE__ );
 $cc_woo_plugin->run();
+
+// Declare compatibility with custom order tables for WooCommerce.
+add_action(
+	'before_woocommerce_init',
+	function () {
+		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+		}
+	}
+);


### PR DESCRIPTION
Hooks in to WC's system to mark plugins as compatible or incompatible with "High Performance Order Storage" which we don't do anything with, so we are good to mark as compatible.