### PR TITLE
run this save checkout only when in checkout

### DIFF
--- a/src/AbandonedCheckouts/CheckoutHandler.php
+++ b/src/AbandonedCheckouts/CheckoutHandler.php
@@ -119,7 +119,9 @@ class CheckoutHandler extends Service {
 	 * @since  1.2.0
 	 */
 	public function update_checkout_data() {
-		$this->save_checkout_data();
+		if ( is_checkout() ) {
+			$this->save_checkout_data();
+		}
 	}
 
 	/**

--- a/src/AbandonedCheckouts/CheckoutHandler.php
+++ b/src/AbandonedCheckouts/CheckoutHandler.php
@@ -119,7 +119,7 @@ class CheckoutHandler extends Service {
 	 * @since  1.2.0
 	 */
 	public function update_checkout_data() {
-		if ( is_checkout() ) {
+		if ( is_cart() || is_checkout() ) {
 			$this->save_checkout_data();
 		}
 	}


### PR DESCRIPTION
Prevents running `save_checkout_data()` too frequently and when away from the checkout page, for the callback on the `woocommerce_cart_updated` hook.

See https://webdevstudios.atlassian.net/browse/CC-430