### PR TITLE
new code for admin notifications regarding plugin updates being available

### DIFF
--- a/src/Utility/AdminNotifications.php
+++ b/src/Utility/AdminNotifications.php
@@ -183,7 +183,7 @@ class AdminNotifications {
 		);
 	}
 
-	function maybe_show_update_available_notification() { return true;
+	function maybe_show_update_available_notification() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return false;
 		}


### PR DESCRIPTION
This PR adds a new admin notification if the correct conditions are met and if the plugin is currently outdated compared to what's available on WordPress.org.

This is similar to the PR we have for the Forms plugin to do the same thing: https://github.com/WebDevStudios/constant-contact-forms/pull/674

See https://webdevstudios.atlassian.net/browse/CC-427