### PR TITLE
Release 2.4.0

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,14 +2,14 @@
 Contributors: constantcontact, webdevstudios, znowebdev, jmichaelward, ggwicz, ravedev, newyorkerlaura
 Tags: Constant Contact, WooCommerce, email marketing, marketing automation, abandoned cart
 Requires at least: 5.2.2
-Tested up to: 6.7.2
-Stable tag: 2.3.2
+Tested up to: 6.8.1
+Stable tag: 2.4.0
 Requires PHP: 7.2
 License: GPLv3
 
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
-Add products to your emails and sync your contacts.
+Add products to your list emails and sync your contacts.
 
 == Description ==
 
@@ -70,6 +70,9 @@ You've connected your WooCommerce store to Constant Contact, promoted your WooCo
 [Learn more with our step-by-step revenue reporting guide.](https://knowledgebase.constantcontact.com/articles/KnowledgeBase/36892-View-Recovered-Revenue-from-the-WooCommerce-Abandoned-Cart-Reminder-Email?q=woocommerce*&lang=en_US)
 
 == Changelog ==
+
+= 2.4.0 =
+* Added: clear webhooks and API connections on disconnection processes.
 
 = 2.3.2 =
 * Fixed: Uncaught fatal error from Abandoned cart checkout recovery.

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: constantcontact, webdevstudios, znowebdev, jmichaelward, ggwicz, ravedev, newyorkerlaura
 Tags: Constant Contact, WooCommerce, email marketing, marketing automation, abandoned cart
 Requires at least: 5.2.2
-Tested up to: 6.8.1
+Tested up to: 6.8.2
 Stable tag: 2.4.0
 Requires PHP: 7.2
 License: GPLv3

--- a/plugin.php
+++ b/plugin.php
@@ -8,7 +8,7 @@
  * Plugin Name: Constant Contact + WooCommerce
  * Description: Add products to your emails and sync your contacts.
  * Plugin URI: https://github.com/WebDevStudios/constant-contact-woocommerce
- * Version: 2.3.2
+ * Version: 2.4.0
  * Author: Constant Contact
  * Author URI: https://www.constantcontact.com/
  * Text Domain: constant-contact-woocommerce

--- a/src/Api/KeyManager.php
+++ b/src/Api/KeyManager.php
@@ -80,7 +80,7 @@ class KeyManager extends Service {
 			return false;
 		}
 
-		if ( ! $this->is_woo_commerce_api_key_query( $query ) ) {
+		if ( ! $this->is_woocommerce_api_key_query( $query ) ) {
 			return false;
 		}
 
@@ -139,7 +139,7 @@ SQL;
 	 * @param string $query The query to test.
 	 * @return bool
 	 */
-	private function is_woo_commerce_api_key_query( $query ) {
+	private function is_woocommerce_api_key_query( $query ) {
 		return false !== stripos( $query, 'woocommerce_api_keys' );
 	}
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -51,7 +51,7 @@ final class Plugin extends ServiceRegistrar {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const PLUGIN_VERSION = '2.3.2';
+	const PLUGIN_VERSION = '2.4.0';
 
 	/**
 	 * Whether the plugin is currently active.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,6 +15,7 @@ use WebDevStudios\CCForWoo\Utility\CheckoutBlockNewsletter;
 use WebDevStudios\CCForWoo\Utility\HealthPanel;
 use WebDevStudios\CCForWoo\Utility\PluginCompatibilityCheck;
 use WebDevStudios\CCForWoo\Utility\AdminNotifications;
+use WebDevStudios\CCForWoo\Utility\WebhookAPICleanup;
 use WebDevStudios\OopsWP\Structure\ServiceRegistrar;
 use WebDevStudios\CCForWoo\View\ViewRegistrar;
 use WebDevStudios\CCForWoo\View\Admin\Notice;
@@ -335,6 +336,10 @@ final class Plugin extends ServiceRegistrar {
 		delete_option( ConnectionStatus::CC_FIRST_CONNECTION );
 		delete_option( ConnectionStatus::CC_CONNECTION_ESTABLISHED_KEY );
 
+		global $wpdb;
+		$cleanup = new WebhookAPICleanup( $wpdb );
+		$cleanup->clear_webhooks();
+		$cleanup->clear_api_connections();
 
 		// WooCommerce Options
 		delete_option( 'cc_woo_store_information_first_name' );

--- a/src/Utility/WebhookAPICleanup.php
+++ b/src/Utility/WebhookAPICleanup.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Webhook and API cleanup.
  *
- * @since   NEXT
+ * @since   2.4.0
  * @author  WebDevStudios.
  * @package cc-woo
  */
@@ -12,7 +12,7 @@ namespace WebDevStudios\CCForWoo\Utility;
 /**
  * Webhook and API cleanup class.
  *
- * @since NEXT
+ * @since 2.4.0
  */
 class WebhookAPICleanup {
 
@@ -35,7 +35,7 @@ class WebhookAPICleanup {
 	/**
 	 * Clear out all of our webhooks by name.
 	 *
-	 * @since NEXT
+	 * @since 2.4.0
 	 */
 	public function clear_webhooks() {
 		$query = "DELETE FROM {$this->wpdb->prefix}wc_webhooks WHERE topic = '%s'";
@@ -50,7 +50,7 @@ class WebhookAPICleanup {
 	/**
 	 * Clear out all of our API connections.
 	 *
-	 * @since NEXT
+	 * @since 2.4.0
 	 */
 	public function clear_api_connections() {
 		$query  = "DELETE FROM {$this->wpdb->prefix}woocommerce_api_keys WHERE description LIKE 'Constant Contact - API%'";

--- a/src/Utility/WebhookAPICleanup.php
+++ b/src/Utility/WebhookAPICleanup.php
@@ -1,13 +1,42 @@
 <?php
+/**
+ * WooCommerce Webhook and API cleanup.
+ *
+ * @since   NEXT
+ * @author  WebDevStudios.
+ * @package cc-woo
+ */
 
 namespace WebDevStudios\CCForWoo\Utility;
 
+/**
+ * Webhook and API cleanup class.
+ *
+ * @since NEXT
+ */
 class WebhookAPICleanup {
 
+	/**
+	 * WPDB class instance.
+	 *
+	 * @var \WPDB $wpdb
+	 */
 	protected \WPDB $wpdb;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param \WPDB $wpdb
+	 */
 	public function __construct( \WPDB $wpdb) {
 		$this->wpdb = $wpdb;
 	}
+
+	/**
+	 * Clear out all of our webhooks by name.
+	 *
+	 * @since NEXT
+	 */
 	public function clear_webhooks() {
 		$query = "DELETE FROM {$this->wpdb->prefix}wc_webhooks WHERE topic = '%s'";
 		$result = $this->wpdb->query(
@@ -18,6 +47,11 @@ class WebhookAPICleanup {
 		);
 	}
 
+	/**
+	 * Clear out all of our API connections.
+	 *
+	 * @since NEXT
+	 */
 	public function clear_api_connections() {
 		$query  = "DELETE FROM {$this->wpdb->prefix}woocommerce_api_keys WHERE description LIKE 'Constant Contact - API%'";
 		$result = $this->wpdb->query(

--- a/src/Utility/WebhookAPICleanup.php
+++ b/src/Utility/WebhookAPICleanup.php
@@ -23,7 +23,5 @@ class WebhookAPICleanup {
 		$result = $this->wpdb->query(
 			$query
 		);
-
-		$g = '';
 	}
 }

--- a/src/Utility/WebhookAPICleanup.php
+++ b/src/Utility/WebhookAPICleanup.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WebDevStudios\CCForWoo\Utility;
+
+class WebhookAPICleanup {
+
+	protected \WPDB $wpdb;
+	public function __construct( \WPDB $wpdb) {
+		$this->wpdb = $wpdb;
+	}
+	public function clear_webhooks() {
+		$query = "DELETE FROM {$this->wpdb->prefix}wc_webhooks WHERE topic = '%s'";
+		$result = $this->wpdb->query(
+			$this->wpdb->prepare(
+				$query,
+				'action.wc_ctct_disconnect'
+			)
+		);
+	}
+
+	public function clear_api_connections() {
+		$query  = "DELETE FROM {$this->wpdb->prefix}woocommerce_api_keys WHERE description LIKE 'Constant Contact - API%'";
+		$result = $this->wpdb->query(
+			$query
+		);
+
+		$g = '';
+	}
+}

--- a/src/View/Admin/Disconnect.php
+++ b/src/View/Admin/Disconnect.php
@@ -6,6 +6,8 @@ use WebDevStudios\CCForWoo\Utility\DebugLogging;
 use WebDevStudios\OopsWP\Structure\Service;
 use WebDevStudios\CCForWoo\Meta\ConnectionStatus;
 use WebDevStudios\CCForWoo\AbandonedCheckouts\CheckoutsTable;
+use WebDevStudios\CCForWoo\Utility\WebhookAPICleanup;
+
 /**
  * Disconnects the plugin from Constant Contact WOO.
  *
@@ -64,13 +66,16 @@ class Disconnect extends Service {
 
         wp_clear_scheduled_hook( 'cc_woo_check_expired_checkouts' );
 
+		global $wpdb;
+		$cleanup = new WebhookAPICleanup( $wpdb );
+		$cleanup->clear_webhooks();
+		$cleanup->clear_api_connections();
 
 		delete_option( CheckoutsTable::DB_VERSION_OPTION_NAME );
 		delete_option( ConnectionStatus::CC_CONNECTION_USER_ID );
 		delete_option( ConnectionStatus::CC_FIRST_CONNECTION );
 		delete_option( ConnectionStatus::CC_CONNECTION_ESTABLISHED_KEY );
 		delete_option( ConnectionStatus::CC_CONNECTED_TIME );
-
 
 		// WooCommerce Options
 		delete_option( 'cc_woo_store_information_first_name' );

--- a/tests/phpunit/Api/KeyManagerTest.php
+++ b/tests/phpunit/Api/KeyManagerTest.php
@@ -111,7 +111,7 @@ class KeyManagerTest extends TestCase {
 	 */
 	private function check_if_woo_api_query( $query ) {
 		$object = new KeyManager();
-		$method = new \ReflectionMethod( $object, 'is_woo_commerce_api_key_query' );
+		$method = new \ReflectionMethod( $object, 'is_woocommerce_api_key_query' );
 
 		$method->setAccessible( true );
 


### PR DESCRIPTION
This PR merges in all the changes regarding version 2.4.0.

Version 2.4.0 is going to add support for clearing out existing created webhooks as well as API connections upon CTCT Woo deactivation process. This will clean up those tables.

It also corrects one method name to not have a space in "woocommerce"